### PR TITLE
Fix subpage routing problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,27 +4,17 @@ A web app for sharing secrets.
 
 Development of this app is being presented as a series of videos on [The Friendly TL's YouTube channel](https://www.youtube.com/@FriendlyTL).
 
-## Build Deployment Container
+## Prod
 
 ```sh
-# Build production container
+# Build prod container
 ./build.sh
 
-# Run production container
+# Run prod container at http://127.0.0.1:8000
 docker run -p 8000:8000 gcr.io/cipherly/cipherly
-```
 
-## Deploy to Prod
-
-```sh
-# Set the project
-gcloud config set project cipherly
-
-# Upload to GCR
-gcloud builds submit --tag gcr.io/cipherly/cipherly
-
-# Deploy
-gcloud run deploy cipherly --image gcr.io/cipherly/cipherly --platform managed --region us-west1 --allow-unauthenticated
+# Deploy to prod
+./deploy.sh
 ```
 
 ## Message Format

--- a/backend/cipherly.py
+++ b/backend/cipherly.py
@@ -1,6 +1,5 @@
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
-from starlette.exceptions import HTTPException
 
 app = FastAPI()
 
@@ -10,15 +9,4 @@ def read_root():
     return {"Hello": "World"}
 
 
-class SPAStaticFiles(StaticFiles):
-    async def get_response(self, path: str, scope):
-        try:
-            return await super().get_response(path, scope)
-        except HTTPException as ex:
-            if ex.status_code == 404:
-                return await super().get_response("index.html", scope)
-            else:
-                raise ex
-
-
-app.mount("/", SPAStaticFiles(directory="frontend", html=True), name="static")
+app.mount("/", StaticFiles(directory="frontend", html=True), name="static")

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Set the project
+gcloud config set project cipherly
+
+# Upload to Google Container Registry
+gcloud builds submit --tag gcr.io/cipherly/cipherly
+
+# Deploy to prod
+gcloud run deploy cipherly --image gcr.io/cipherly/cipherly --platform managed --region us-west1 --allow-unauthenticated

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -5,17 +5,17 @@
 
 <main>
   <div class="space-y-6 pb-16">
-    <div class="flex flex-col space-y-8 lg:flex-row lg:space-x-12 lg:space-y-0">
+    <div class="flex flex-col space-y-8 lg:flex-row lg:space-y-0">
       <aside class="bg-slate-400 p-2 lg:w-1/5">
         <Sidebar
           items={[
             { title: "Home", href: "/" },
-            { title: "Encrypt", href: "/password/encrypt" },
-            { title: "Decrypt", href: "/password" },
+            { title: "Encrypt", href: "/password/encrypt/" },
+            { title: "Decrypt", href: "/password/" },
           ]}
         />
       </aside>
-      <div class="flex-1 p-2 lg:max-w-2xl">
+      <div class="flex-1 p-2">
         <slot />
       </div>
     </div>

--- a/frontend/src/routes/+layout.ts
+++ b/frontend/src/routes/+layout.ts
@@ -1,2 +1,3 @@
 export const prerender = true;
 export const ssr = false;
+export const trailingSlash = "always";


### PR DESCRIPTION
This fixes the problem that if you refresh the cipherly.app at any subpage, for example cipherly.app/password/encrypt, the page will break. I've also already redeployed and tested. Also did some minor fixes to the look and feel.