### PR TITLE
Fix auth being unreliable

### DIFF
--- a/frontend/src/routes/auth/+page.svelte
+++ b/frontend/src/routes/auth/+page.svelte
@@ -48,7 +48,9 @@
     </div>
 
     <div class={$user === null ? "" : "hidden"}>
-      <div id="login-button"><Skeleton class="h-10 w-full" /></div>
+      <div id="login-button" class="w-[200px]" style="color-scheme:light">
+        <Skeleton class="h-10" />
+      </div>
     </div>
 
     {#if $user !== null}

--- a/frontend/src/routes/auth/+page.svelte
+++ b/frontend/src/routes/auth/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { login, logout, token, user } from "$lib/auth";
+  import { logout, renderLoginButton, token, user } from "$lib/auth";
   import * as Cipherly from "$lib/cipherly";
   import Avatar from "$lib/components/Avatar.svelte";
   import CopyText from "$lib/components/CopyText.svelte";
@@ -9,6 +9,11 @@
   import { Label } from "$lib/components/ui/label";
   import { Skeleton } from "$lib/components/ui/skeleton";
   import { Textarea } from "$lib/components/ui/textarea";
+  import { onMount } from "svelte";
+
+  onMount(() => {
+    renderLoginButton(document.getElementById("login-button"));
+  });
 
   let payload = "";
   let plainText: Promise<string> | null = null;
@@ -42,19 +47,11 @@
       </h1>
     </div>
 
-    {#if $user === null}
-      <div class="pt-4">
-        <Button
-          class="flex min-w-[140px] space-x-2"
-          variant="secondary"
-          type="button"
-          on:click={login}
-        >
-          <Google class="w-4" />
-          <span>Login to Decrypt</span>
-        </Button>
-      </div>
-    {:else}
+    <div class={$user === null ? "" : "hidden"}>
+      <div id="login-button"><Skeleton class="h-10 w-full" /></div>
+    </div>
+
+    {#if $user !== null}
       <div class="flex items-center space-x-4">
         <div
           class="flex items-center space-x-4 rounded-3xl bg-muted px-4 py-2 text-muted-foreground"


### PR DESCRIPTION
So, the way we were calling login() before is technically not allowed. If we want an interactive button, we have to ask the library to create it for us. But there's all kinds of restrictions -- like, don't try to render the button before the library has finished loading... sigh. This is the simplest solution I found that works.

<img width="1186" alt="Screenshot 2024-04-01 at 5 25 49 PM" src="https://github.com/shadanan/cipherly/assets/361429/7ad8d56f-5233-4ef9-8dc4-62ba41e8398f">

Unfortunately, it behaves badly in dark mode:

<img width="1206" alt="Screenshot 2024-04-01 at 5 29 28 PM" src="https://github.com/shadanan/cipherly/assets/361429/dbb75a33-4891-455e-b4e9-6753b23eb79f">

Let's merge as is, and I'll do the demo in light mode.