### PR TITLE
Fix all the text and simplify copy / paste of payload

### DIFF
--- a/frontend/src/lib/cipherly.ts
+++ b/frontend/src/lib/cipherly.ts
@@ -44,6 +44,18 @@ export function generateIv(): Uint8Array {
   return crypto.getRandomValues(new Uint8Array(12));
 }
 
+function cipherlyHost(): string {
+  return `${location.protocol}//${location.host}`;
+}
+
+function extractHash(data: string): string {
+  const hashPos = data.indexOf("#");
+  if (hashPos !== -1) {
+    return data.slice(hashPos + 1);
+  }
+  return data;
+}
+
 type PasswordPayload = {
   salt: Uint8Array;
   iv: Uint8Array;
@@ -51,15 +63,11 @@ type PasswordPayload = {
 };
 
 export function encodePasswordPayload(payload: PasswordPayload): string {
-  return encodeMessagePack(payload);
+  return `${cipherlyHost()}/password/#${encodeMessagePack(payload)}`;
 }
 
-export function decodePasswordPayload(hash: string): PasswordPayload {
-  return decodeMessagePack(hash) as PasswordPayload;
-}
-
-export function passwordUrl(): string {
-  return `${location.protocol}//${location.host}/password/#`;
+export function decodePasswordPayload(data: string): PasswordPayload {
+  return decodeMessagePack(extractHash(data)) as PasswordPayload;
 }
 
 export async function deriveKey(
@@ -114,15 +122,11 @@ type AuthPayload = {
 };
 
 export function encodeAuthPayload(payload: AuthPayload): string {
-  return encodeMessagePack(payload);
+  return `${cipherlyHost()}/auth/#${encodeMessagePack(payload)}`;
 }
 
-export function decodeAuthPayload(hash: string): AuthPayload {
-  return decodeMessagePack(hash) as AuthPayload;
-}
-
-export function authUrl(): string {
-  return `${location.protocol}//${location.host}/auth/#`;
+export function decodeAuthPayload(data: string): AuthPayload {
+  return decodeMessagePack(extractHash(data)) as AuthPayload;
 }
 
 type Envelope = {

--- a/frontend/src/routes/auth/+page.svelte
+++ b/frontend/src/routes/auth/+page.svelte
@@ -19,7 +19,7 @@
   let plainText: Promise<string> | null = null;
 
   if (location.hash) {
-    payload = location.hash.slice(1);
+    payload = location.href;
   }
 
   async function decrypt(payload: string): Promise<string> {
@@ -43,7 +43,7 @@
   >
     <div>
       <h1 class="text-xl font-bold text-foreground">
-        Authorization based decryption
+        Authorization Based Decryption
       </h1>
     </div>
 
@@ -74,7 +74,7 @@
         <div class="space-y-2">
           <Label
             class="text-background-foreground text-sm uppercase tracking-wider"
-            for="plainText">Ciphertext Envelope</Label
+            for="payload">Ciphertext Payload</Label
           >
           <Textarea
             required
@@ -98,7 +98,7 @@
       class="border-background-foreground space-y-6 rounded-md border-2 bg-background p-8"
     >
       <div>
-        <h1 class="text-xl font-bold text-foreground">Encrypted content</h1>
+        <h1 class="text-xl font-bold text-foreground">Decrypted Content</h1>
       </div>
       {#await plainText}
         <div class="space-y-6 py-6">
@@ -118,22 +118,20 @@
             id="plainText"
             disabled
             value={plainText}
-            placeholder="The decrypted plainText"
+            placeholder="The decrypted plaintext"
           />
         </div>
-        <CopyText label="PlainText" text={plainText} />
+        <CopyText label="Plaintext" text={plainText} />
       {:catch err}
         <Alert.Root variant="destructive" class="space-y-2 rounded">
           {#if err.code === 401}
             <Alert.Title>Unauthorized</Alert.Title>
-            <Alert.Description
-              >You are not authorized to decrypt this secret.</Alert.Description
-            >
+            <Alert.Description>
+              You are not authorized to decrypt this secret.
+            </Alert.Description>
           {:else}
             <Alert.Title>Failed to Decrypt</Alert.Title>
-            <Alert.Description
-              >Password is incorrect or ciphertext is invalid.</Alert.Description
-            >
+            <Alert.Description>Ciphertext is invalid.</Alert.Description>
           {/if}
         </Alert.Root>
       {/await}

--- a/frontend/src/routes/auth/encrypt/+page.svelte
+++ b/frontend/src/routes/auth/encrypt/+page.svelte
@@ -12,7 +12,7 @@
 
   let authorizedEmails = new Set<string>([]);
   let email = "";
-  let plaintext = "";
+  let plainText = "";
   let payload: Promise<string> | null = null;
 
   async function encrypt(plainText: string, emails: string[]): Promise<string> {
@@ -42,7 +42,7 @@
   >
     <div>
       <h1 class="text-xl font-bold text-foreground">
-        Authorization based encryption
+        Authorization Based Encryption
       </h1>
     </div>
 
@@ -50,21 +50,21 @@
       class="space-y-6"
       on:submit|preventDefault={() => {
         appendAndClearEmail();
-        payload = encrypt(plaintext, Array.from(authorizedEmails));
+        payload = encrypt(plainText, Array.from(authorizedEmails));
       }}
     >
       <div class="space-y-2">
         <Label
           class="text-background-foreground text-sm uppercase tracking-wider"
-          for="plaintext"
+          for="plainText"
         >
-          Ciphertext Envelope
+          Plaintext
         </Label>
         <Textarea
           required
           class="border-2 border-muted text-base text-foreground focus:ring-0 focus-visible:ring-0"
-          id="plaintext"
-          bind:value={plaintext}
+          id="plainText"
+          bind:value={plainText}
           placeholder="The plaintext secret to encrypt"
         />
       </div>
@@ -133,7 +133,7 @@
       class="border-background-foreground space-y-6 rounded-md border-2 bg-background p-8"
     >
       <div>
-        <h1 class="text-xl font-bold text-foreground">Encrypted content</h1>
+        <h1 class="text-xl font-bold text-foreground">Encrypted Content</h1>
       </div>
 
       {#await payload}
@@ -142,14 +142,13 @@
           <Skeleton class="h-10 w-full" />
         </div>
       {:then payload}
-        {@const url = Cipherly.authUrl() + payload}
-
         <div class="space-y-2">
           <Label
             for="payload"
             class="text-background-foreground text-sm uppercase tracking-wider"
-            >Ciphertext Envelope</Label
           >
+            Ciphertext Payload
+          </Label>
           <Textarea
             class="disabled:opacity-1 border-2 border-muted text-base focus-visible:outline-none focus-visible:ring-0 disabled:cursor-text disabled:text-green-600"
             id="payload"
@@ -160,7 +159,6 @@
 
         <div class="space-x-2 pt-4">
           <CopyText label="Ciphertext" text={payload} />
-          <CopyText label="Decrypt URL" text={url} />
         </div>
       {:catch error}
         <Alert.Root variant="destructive" class="space-y-2 rounded">

--- a/frontend/src/routes/password/+page.svelte
+++ b/frontend/src/routes/password/+page.svelte
@@ -13,7 +13,7 @@
   let plainText: Promise<string> | null = null;
 
   if (location.hash) {
-    payload = location.hash.slice(1);
+    payload = location.href;
   }
 
   async function decrypt(payload: string, password: string): Promise<string> {
@@ -30,7 +30,7 @@
   >
     <div>
       <h1 class="text-xl font-bold text-foreground">
-        Password based decryption
+        Password Based Decryption
       </h1>
     </div>
 
@@ -41,12 +41,12 @@
       <div class="space-y-2">
         <Label
           class="text-background-foreground text-sm uppercase tracking-wider"
-          for="plainText">Ciphertext Envelope</Label
+          for="payload">Ciphertext Payload</Label
         >
         <Textarea
+          id="payload"
           required
           class="border-2 border-muted text-base text-foreground focus:ring-0 focus-visible:ring-0"
-          id="payload"
           bind:value={payload}
           placeholder="The ciphertext payload to be decrypted"
         />
@@ -55,9 +55,10 @@
       <div class="space-y-2">
         <Label
           class="text-background-foreground text-sm uppercase tracking-wider"
-          for="plainText">Password</Label
+          for="password">Password</Label
         >
         <Input
+          id="password"
           class="border-2 border-muted text-base text-foreground focus:ring-0 focus-visible:ring-0"
           type="password"
           placeholder="The password to use for decryption"
@@ -66,9 +67,9 @@
       </div>
 
       <div class="pt-4">
-        <Button class="min-w-[140px] text-lg font-bold" type="submit"
-          >Decrypt</Button
-        >
+        <Button class="min-w-[140px] text-lg font-bold" type="submit">
+          Decrypt
+        </Button>
       </div>
     </form>
   </div>
@@ -78,7 +79,7 @@
       class="border-background-foreground space-y-6 rounded-md border-2 bg-background p-8"
     >
       <div>
-        <h1 class="text-xl font-bold text-foreground">Encrypted content</h1>
+        <h1 class="text-xl font-bold text-foreground">Decrypted Content</h1>
       </div>
       {#await plainText}
         <div class="space-y-6 py-6">
@@ -98,16 +99,16 @@
             id="plainText"
             disabled
             value={plainText}
-            placeholder="The decrypted plainText"
+            placeholder="The decrypted plaintext"
           />
         </div>
-        <CopyText label="Plain text" text={plainText} />
+        <CopyText label="Plaintext" text={plainText} />
       {:catch}
         <Alert.Root variant="destructive" class="space-y-2 rounded">
           <Alert.Title>Failed to Decrypt</Alert.Title>
-          <Alert.Description
-            >Password is incorrect or ciphertext is invalid.</Alert.Description
-          >
+          <Alert.Description>
+            Password is incorrect or ciphertext is invalid.
+          </Alert.Description>
         </Alert.Root>
       {/await}
     </div>

--- a/frontend/src/routes/password/encrypt/+page.svelte
+++ b/frontend/src/routes/password/encrypt/+page.svelte
@@ -10,7 +10,7 @@
 
   let plainText = "";
   let password = "";
-  let envelope: Promise<string> | null = null;
+  let payload: Promise<string> | null = null;
 
   async function encrypt(plainText: string, password: string): Promise<string> {
     const salt = Cipherly.generateSalt();
@@ -33,13 +33,13 @@
   >
     <div>
       <h1 class="text-xl font-bold text-foreground">
-        Password based encryption
+        Password Based Encryption
       </h1>
     </div>
 
     <form
       class="space-y-6"
-      on:submit|preventDefault={() => (envelope = encrypt(plainText, password))}
+      on:submit|preventDefault={() => (payload = encrypt(plainText, password))}
     >
       <div class="space-y-2">
         <Label
@@ -58,9 +58,10 @@
       <div class="space-y-2">
         <Label
           class="text-background-foreground text-sm uppercase tracking-wider"
-          for="plainText">Password</Label
+          for="password">Password</Label
         >
         <Input
+          id="password"
           class="border-2 border-muted text-base text-foreground focus:ring-0 focus-visible:ring-0"
           placeholder="The password to use for encryption"
           bind:value={password}
@@ -68,47 +69,44 @@
       </div>
 
       <div class="pt-4">
-        <Button class="min-w-[140px] text-lg font-bold" type="submit"
-          >Encrypt</Button
-        >
+        <Button class="min-w-[140px] text-lg font-bold" type="submit">
+          Encrypt
+        </Button>
       </div>
     </form>
   </div>
 
-  {#if envelope}
+  {#if payload}
     <div
       class="border-background-foreground space-y-6 rounded-md border-2 bg-card p-8"
     >
       <div>
-        <h1 class="text-xl font-bold text-foreground">Encrypted content</h1>
+        <h1 class="text-xl font-bold text-foreground">Encrypted Content</h1>
       </div>
 
-      {#await envelope}
+      {#await payload}
         <div class="space-y-6 py-6">
           <Skeleton class="h-20 w-full" />
           <Skeleton class="h-10 w-full" />
         </div>
-      {:then envelope}
-        {@const url = Cipherly.passwordUrl() + envelope}
-
+      {:then payload}
         <div class="space-y-2">
           <Label
-            for="envelope"
+            for="payload"
             class="text-background-foreground text-sm uppercase tracking-wider"
           >
-            Ciphertext Envelope
+            Ciphertext Payload
           </Label>
           <Textarea
             class="focus-visible:ring-none disabled:opacity-1 border-2  border-muted text-base focus-visible:outline-none disabled:cursor-text disabled:text-green-600"
-            id="envelope"
+            id="payload"
             disabled
-            value={envelope}
+            value={payload}
             placeholder="The plain text secret to encrypt"
           />
         </div>
         <div class="space-x-2 pt-4">
-          <CopyText label="Decrypt CipherText" text={envelope} />
-          <CopyText label="Decrypt URL" text={url} />
+          <CopyText label="Ciphertext" text={payload} />
         </div>
       {:catch error}
         <Alert.Root variant="destructive" class="space-y-2 rounded">


### PR DESCRIPTION
- There was a regression and we were using the word envelope incorrectly in a number of places. 
- Tidy up the usage of those various terms, fix the label `for` argument. 
- The copy / paste buttons distinguish between URLs and payloads. This is not that intuitive to a user. In general, we always just want to use the URL, so now, payload refers to the full URL. And delete that old payload button. Also, update Cipherly JS to support both the old payload format (without the URL part). So if you just paste the part after the hash, Cipherly will still decrypt correctly.