### PR TITLE
Add form validation with zod

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,7 +17,8 @@
         "lucide-svelte": "^0.338.0",
         "mode-watcher": "^0.3.0",
         "tailwind-merge": "^2.2.1",
-        "tailwind-variants": "^0.2.0"
+        "tailwind-variants": "^0.2.0",
+        "zod": "^3.22.4"
       },
       "devDependencies": {
         "@sveltejs/adapter-static": "^3.0.1",
@@ -3804,6 +3805,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,7 @@
     "lucide-svelte": "^0.338.0",
     "mode-watcher": "^0.3.0",
     "tailwind-merge": "^2.2.1",
-    "tailwind-variants": "^0.2.0"
+    "tailwind-variants": "^0.2.0",
+    "zod": "^3.22.4"
   }
 }

--- a/frontend/src/lib/cipherly.ts
+++ b/frontend/src/lib/cipherly.ts
@@ -56,35 +56,6 @@ function extractHash(data: string): string {
   return data;
 }
 
-export enum EncryptionScheme {
-  Password = 0,
-  Auth = 1,
-}
-
-type PayloadHeader = {
-  es: EncryptionScheme;
-};
-
-type PasswordBody = {
-  s: Uint8Array; // salt
-  iv: Uint8Array; // initialization vector
-  ct: Uint8Array; // ciphertext
-};
-
-export type PasswordPayload = PayloadHeader & PasswordBody;
-
-export function encodePasswordPayload(payload: PasswordBody): string {
-  const msgPackPayload: PasswordPayload = {
-    es: EncryptionScheme.Password,
-    ...payload,
-  };
-  return decryptUrl(encodeMessagePack(msgPackPayload));
-}
-
-export function decodePasswordPayload(data: string): PasswordPayload {
-  return decodeMessagePack(extractHash(data)) as PasswordPayload;
-}
-
 export async function deriveKey(
   password: Uint8Array,
   salt: Uint8Array,
@@ -131,6 +102,69 @@ export async function decrypt(
   );
 }
 
+export enum EncryptionScheme {
+  Password = 0,
+  Auth = 1,
+}
+
+type PayloadHeader = {
+  es: EncryptionScheme;
+};
+
+type PasswordBody = {
+  s: Uint8Array; // salt
+  iv: Uint8Array; // initialization vector
+  ct: Uint8Array; // ciphertext
+};
+
+export type PasswordPayload = PayloadHeader & PasswordBody;
+
+export function isPasswordPayload(payload: any): payload is PasswordPayload {
+  return (
+    typeof payload === "object" &&
+    "es" in payload &&
+    payload.es === EncryptionScheme.Password &&
+    "s" in payload &&
+    "iv" in payload &&
+    "ct" in payload
+  );
+}
+
+export function encodePasswordPayload(payload: PasswordBody): string {
+  const msgPackPayload: PasswordPayload = {
+    es: EncryptionScheme.Password,
+    ...payload,
+  };
+  return decryptUrl(encodeMessagePack(msgPackPayload));
+}
+
+export function decodePasswordPayload(data: string): PasswordPayload {
+  return decodeMessagePack(extractHash(data)) as PasswordPayload;
+}
+
+export async function passwordEncrypt(
+  plainText: string,
+  password: string,
+): Promise<string> {
+  const salt = generateSalt();
+  const key = await deriveKey(encodeUtf8(password), salt);
+
+  const iv = generateIv();
+  const cipherText = await encrypt(encodeUtf8(plainText), key, iv);
+
+  return encodePasswordPayload({ s: salt, iv: iv, ct: cipherText });
+}
+
+export async function passwordDecrypt(
+  payload: Payload,
+  password: string,
+): Promise<string> {
+  const { s: salt, iv: iv, ct: cipherText } = payload as PasswordPayload;
+  const key = await deriveKey(encodeUtf8(password), salt);
+  const plainText = await decrypt(cipherText, key, iv);
+  return decodeUtf8(plainText);
+}
+
 type AuthBody = {
   k: string; // kid
   n: Uint8Array; // nonce
@@ -140,6 +174,19 @@ type AuthBody = {
 };
 
 export type AuthPayload = PayloadHeader & AuthBody;
+
+export function isAuthPayload(payload: any): payload is AuthPayload {
+  return (
+    typeof payload === "object" &&
+    "es" in payload &&
+    payload.es === EncryptionScheme.Auth &&
+    "k" in payload &&
+    "n" in payload &&
+    "se" in payload &&
+    "iv" in payload &&
+    "ct" in payload
+  );
+}
 
 export function encodeAuthPayload(payload: AuthBody): string {
   const msgPackPayload: AuthPayload = {
@@ -157,32 +204,6 @@ export type Payload = PasswordPayload | AuthPayload;
 
 export function decodePayload(data: string): Payload {
   return decodeMessagePack(extractHash(data)) as Payload;
-}
-
-export async function passwordDecrypt(
-  payload: Payload,
-  password: string,
-): Promise<string> {
-  const { s: salt, iv: iv, ct: cipherText } = payload as PasswordPayload;
-  const key = await deriveKey(encodeUtf8(password), salt);
-  const plainText = await decrypt(cipherText, key, iv);
-  return decodeUtf8(plainText);
-}
-
-export async function authDecrypt(
-  payload: Payload,
-  token: string,
-): Promise<string> {
-  const {
-    k: kid,
-    n: nonce,
-    se: data,
-    iv: iv,
-    ct: cipherText,
-  } = payload as AuthPayload;
-  const envelope = await unseal({ kid, nonce, data }, token);
-  const plainText = await decrypt(cipherText, envelope.dek, iv);
-  return decodeUtf8(plainText);
 }
 
 type Envelope = {
@@ -248,4 +269,37 @@ export async function unseal(
   );
 
   return { dek, emails: result.emails };
+}
+
+export async function authEncrypt(
+  plainText: string,
+  emails: string[],
+): Promise<string> {
+  const dek = await generateKey();
+  const iv = generateIv();
+  const cipherText = await encrypt(encodeUtf8(plainText), dek, iv);
+  const { kid, nonce, data } = await seal({ dek, emails });
+  return encodeAuthPayload({
+    k: kid,
+    n: nonce,
+    se: data,
+    iv: iv,
+    ct: cipherText,
+  });
+}
+
+export async function authDecrypt(
+  payload: Payload,
+  token: string,
+): Promise<string> {
+  const {
+    k: kid,
+    n: nonce,
+    se: data,
+    iv: iv,
+    ct: cipherText,
+  } = payload as AuthPayload;
+  const envelope = await unseal({ kid, nonce, data }, token);
+  const plainText = await decrypt(cipherText, envelope.dek, iv);
+  return decodeUtf8(plainText);
 }

--- a/frontend/src/lib/form.ts
+++ b/frontend/src/lib/form.ts
@@ -1,7 +1,7 @@
 import { ZodError } from "zod";
 
 export function hasError(
-  validationError: ZodError | undefined,
+  validationError: ZodError | null,
   property: string,
 ): boolean {
   if (!validationError || validationError.isEmpty) return false;
@@ -9,7 +9,7 @@ export function hasError(
 }
 
 export function getError(
-  validationError: ZodError | undefined,
+  validationError: ZodError | null,
   property: string,
 ): string | null {
   if (!validationError || validationError.isEmpty) return null;

--- a/frontend/src/lib/form.ts
+++ b/frontend/src/lib/form.ts
@@ -1,0 +1,26 @@
+import { ZodError, z } from "zod";
+
+// Checkout https://github.com/colinhacks/zod for example validation logic
+export const AuthEncryptFormSchema = z.object({
+  emails: z.array(z.string().email().endsWith("@gmail.com")),
+  plainText: z.string().min(1),
+});
+export type AuthEncryptFormData = z.infer<typeof AuthEncryptFormSchema>;
+
+export function hasError(
+  validationError: ZodError | undefined,
+  property: string,
+): boolean {
+  if (!validationError || validationError.isEmpty) return false;
+  return validationError.issues.some((e) => e.path.includes(property));
+}
+
+export function getError(
+  validationError: ZodError | undefined,
+  property: string,
+): string | null {
+  if (!validationError || validationError.isEmpty) return null;
+  const error = validationError.issues.find((e) => e.path.includes(property));
+  if (!error) return null;
+  return error.message;
+}

--- a/frontend/src/lib/form.ts
+++ b/frontend/src/lib/form.ts
@@ -1,11 +1,4 @@
-import { ZodError, z } from "zod";
-
-// Checkout https://github.com/colinhacks/zod for example validation logic
-export const AuthEncryptFormSchema = z.object({
-  emails: z.array(z.string().email().endsWith("@gmail.com")),
-  plainText: z.string().min(1),
-});
-export type AuthEncryptFormData = z.infer<typeof AuthEncryptFormSchema>;
+import { ZodError } from "zod";
 
 export function hasError(
   validationError: ZodError | undefined,

--- a/frontend/src/routes/auth/+page.svelte
+++ b/frontend/src/routes/auth/+page.svelte
@@ -18,7 +18,7 @@
   });
   type AuthEncryptFormData = z.infer<typeof AuthEncryptFormSchema>;
 
-  let validationError: z.ZodError | undefined;
+  let validationError: z.ZodError | null;
   let formData: AuthEncryptFormData = {
     plainText: "",
     emails: [],
@@ -26,9 +26,7 @@
 
   function validateFormData(formData: AuthEncryptFormData): boolean {
     const validationResult = AuthEncryptFormSchema.safeParse(formData);
-    validationError = validationResult.success
-      ? undefined
-      : validationResult.error;
+    validationError = validationResult.success ? null : validationResult.error;
     return validationResult.success;
   }
 

--- a/frontend/src/routes/auth/+page.svelte
+++ b/frontend/src/routes/auth/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { z } from "zod";
+  import { AlertCircle } from "lucide-svelte";
   import * as Cipherly from "$lib/cipherly";
   import Chip from "$lib/components/Chip.svelte";
   import CopyText from "$lib/components/CopyText.svelte";
@@ -8,9 +10,27 @@
   import { Label } from "$lib/components/ui/label";
   import { Skeleton } from "$lib/components/ui/skeleton";
   import { Textarea } from "$lib/components/ui/textarea";
+  import {
+    type AuthEncryptFormData,
+    AuthEncryptFormSchema,
+    getError,
+    hasError,
+  } from "$lib/form";
 
-  let emails: string[] = [];
-  let plainText = "";
+  let validationError: z.ZodError | undefined;
+  let formData: AuthEncryptFormData = {
+    plainText: "",
+    emails: [],
+  };
+
+  function validateFormData(formData: AuthEncryptFormData): boolean {
+    const validationResult = AuthEncryptFormSchema.safeParse(formData);
+    validationError = validationResult.success
+      ? undefined
+      : validationResult.error;
+    return validationResult.success;
+  }
+
   let payload: Promise<string> | null = null;
 
   async function encrypt(plainText: string, emails: string[]): Promise<string> {
@@ -37,35 +57,61 @@
     <form
       class="space-y-6"
       on:submit|preventDefault={() => {
-        payload = encrypt(plainText, emails);
+        if (validateFormData(formData)) {
+          payload = encrypt(formData.plainText, formData.emails);
+        }
       }}
     >
       <div class="space-y-2">
         <Label
-          class="text-background-foreground text-sm uppercase tracking-wider"
           for="plainText"
+          class="text-background-foreground text-sm uppercase tracking-wider"
         >
           Plaintext
         </Label>
+
+        <!-- PlainText Validation Error  -->
+        {#if getError(validationError, "plainText")}
+          <p class="flex items-center space-x-1 text-xs text-destructive">
+            <AlertCircle class="inline-block h-[12px] w-[12px]"></AlertCircle>
+            <span>{getError(validationError, "plainText")}</span>
+          </p>
+        {/if}
+
         <Textarea
           required
           class="border-2 border-muted text-base text-foreground focus:ring-0 focus-visible:ring-0"
           id="plainText"
-          bind:value={plainText}
+          bind:value={formData.plainText}
           placeholder="The plaintext secret to encrypt"
         />
       </div>
 
       <div class="space-y-2">
+        <!-- Emails Label -->
         <Label
           for="emails"
           class="text-background-foreground text-sm uppercase tracking-wider"
         >
           Authorized Emails
         </Label>
+
+        <!-- Emails Validation Error -->
+        {#if hasError(validationError, "emails")}
+          <p class="flex items-center space-x-1 text-xs text-destructive">
+            <AlertCircle class="inline-block h-[12px] w-[12px]"></AlertCircle>
+            <span>
+              {getError(validationError, "emails")}: {formData.emails.join(
+                ", ",
+              )}
+            </span>
+          </p>
+        {/if}
+
+        <!-- Emails Input Chip  -->
         <Chip
           id="emails"
-          bind:values={emails}
+          bind:values={formData.emails}
           placeholder="List of email addresses authorized to decrypt"
         />
       </div>

--- a/frontend/src/routes/auth/+page.svelte
+++ b/frontend/src/routes/auth/+page.svelte
@@ -10,12 +10,13 @@
   import { Label } from "$lib/components/ui/label";
   import { Skeleton } from "$lib/components/ui/skeleton";
   import { Textarea } from "$lib/components/ui/textarea";
-  import {
-    type AuthEncryptFormData,
-    AuthEncryptFormSchema,
-    getError,
-    hasError,
-  } from "$lib/form";
+  import { getError, hasError } from "$lib/form";
+
+  const AuthEncryptFormSchema = z.object({
+    emails: z.array(z.string().email().endsWith("@gmail.com")),
+    plainText: z.string().min(1).max(20),
+  });
+  type AuthEncryptFormData = z.infer<typeof AuthEncryptFormSchema>;
 
   let validationError: z.ZodError | undefined;
   let formData: AuthEncryptFormData = {

--- a/frontend/src/routes/decrypt/+page.svelte
+++ b/frontend/src/routes/decrypt/+page.svelte
@@ -37,7 +37,6 @@
     .refine((payload) => payload?.hasOwnProperty("es"), {
       message: "Invalid Cipherly payload (missing encryption scheme)",
     })
-
     .refine(
       (payload) => {
         if (payload?.es === Cipherly.EncryptionScheme.Password) {

--- a/frontend/src/routes/decrypt/+page.svelte
+++ b/frontend/src/routes/decrypt/+page.svelte
@@ -66,7 +66,7 @@
       : null;
 
     if (formData.payload?.es === Cipherly.EncryptionScheme.Auth) {
-      return await Cipherly.authDecrypt(formData.payload, $token as string);
+      return await Cipherly.authDecrypt(formData.payload, $token!);
     }
     if (formData.payload?.es === Cipherly.EncryptionScheme.Password) {
       return await Cipherly.passwordDecrypt(formData.payload, password);

--- a/frontend/src/routes/decrypt/+page.svelte
+++ b/frontend/src/routes/decrypt/+page.svelte
@@ -161,19 +161,11 @@
           for="payload">Ciphertext Payload</Label
         >
 
-        {#if hasError(validationError, "payload") || hasError(validationError, "encodedPayload")}
+        {#if hasError(validationError, "payload")}
           {@const payloadErr = getError(validationError, "payload")}
-          {@const encodedPayloadErr = getError(
-            validationError,
-            "encodedPayload",
-          )}
           <p class="flex items-center space-x-1 text-xs text-destructive">
             <AlertCircle class="inline-block h-[12px] w-[12px]"></AlertCircle>
-            {#if encodedPayloadErr}
-              <span>{encodedPayloadErr}</span>
-            {:else}
-              <span>{payloadErr}</span>
-            {/if}
+            <span>{payloadErr}</span>
           </p>
         {/if}
 

--- a/frontend/src/routes/decrypt/auth.svelte
+++ b/frontend/src/routes/decrypt/auth.svelte
@@ -1,24 +1,14 @@
 <script lang="ts">
   import googleLogo from "$lib/assets/google.svg";
   import { logout, renderLoginButton, token, user } from "$lib/auth";
-  import * as Cipherly from "$lib/cipherly";
   import Avatar from "$lib/components/Avatar.svelte";
   import { Button } from "$lib/components/ui/button";
   import Skeleton from "$lib/components/ui/skeleton/skeleton.svelte";
   import { onMount } from "svelte";
 
-  export let payload: Cipherly.AuthPayload;
-
   onMount(() => {
     renderLoginButton(document.getElementById("login-button"));
   });
-
-  export async function decrypt(): Promise<string> {
-    const { k: kid, n: nonce, se: data, iv: iv, ct: cipherText } = payload;
-    const envelope = await Cipherly.unseal({ kid, nonce, data }, $token!);
-    const plainText = await Cipherly.decrypt(cipherText, envelope.dek, iv);
-    return Cipherly.decodeUtf8(plainText);
-  }
 </script>
 
 <div class={$user === null ? "" : "hidden"}>

--- a/frontend/src/routes/decrypt/password.svelte
+++ b/frontend/src/routes/decrypt/password.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
   import Input from "$lib/components/ui/input/input.svelte";
   import Label from "$lib/components/ui/label/label.svelte";
-  import { AlertCircle } from "lucide-svelte";
 
-  export let error: string | null;
   export let value = "";
 </script>
 
@@ -12,15 +10,6 @@
     class="text-background-foreground text-sm uppercase tracking-wider"
     for="password">Password</Label
   >
-
-  {#if error != null && error != ""}
-    <p class="flex items-center space-x-1 text-xs text-destructive">
-      <AlertCircle class="inline-block h-[12px] w-[12px]"></AlertCircle>
-      <span>
-        {error}
-      </span>
-    </p>
-  {/if}
 
   <Input
     id="password"

--- a/frontend/src/routes/decrypt/password.svelte
+++ b/frontend/src/routes/decrypt/password.svelte
@@ -1,17 +1,10 @@
 <script lang="ts">
-  import * as Cipherly from "$lib/cipherly";
   import Input from "$lib/components/ui/input/input.svelte";
   import Label from "$lib/components/ui/label/label.svelte";
+  import { AlertCircle } from "lucide-svelte";
 
-  export let payload: Cipherly.PasswordPayload;
-  let password = "";
-
-  export async function decrypt(): Promise<string> {
-    const { s: salt, iv: iv, ct: cipherText } = payload;
-    const key = await Cipherly.deriveKey(Cipherly.encodeUtf8(password), salt);
-    const plainText = await Cipherly.decrypt(cipherText, key, iv);
-    return Cipherly.decodeUtf8(plainText);
-  }
+  export let error: string | null;
+  export let value = "";
 </script>
 
 <div class="space-y-2">
@@ -19,11 +12,22 @@
     class="text-background-foreground text-sm uppercase tracking-wider"
     for="password">Password</Label
   >
+
+  {#if error != null && error != ""}
+    <p class="flex items-center space-x-1 text-xs text-destructive">
+      <AlertCircle class="inline-block h-[12px] w-[12px]"></AlertCircle>
+      <span>
+        {error}
+      </span>
+    </p>
+  {/if}
+
   <Input
     id="password"
     class="border-2 border-muted text-base text-foreground focus:ring-0 focus-visible:ring-0"
     type="password"
     placeholder="The password to use for decryption"
-    bind:value={password}
+    bind:value
+    required
   />
 </div>

--- a/frontend/src/routes/password/+page.svelte
+++ b/frontend/src/routes/password/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import * as Cipherly from "$lib/cipherly";
+  import { passwordEncrypt } from "$lib/cipherly";
   import CopyText from "$lib/components/CopyText.svelte";
   import Section from "$lib/components/Section.svelte";
   import * as Alert from "$lib/components/ui/alert";
@@ -12,27 +12,14 @@
   let plainText = "";
   let password = "";
   let payload: Promise<string> | null = null;
-
-  async function encrypt(plainText: string, password: string): Promise<string> {
-    const salt = Cipherly.generateSalt();
-    const key = await Cipherly.deriveKey(Cipherly.encodeUtf8(password), salt);
-
-    const iv = Cipherly.generateIv();
-    const cipherText = await Cipherly.encrypt(
-      Cipherly.encodeUtf8(plainText),
-      key,
-      iv,
-    );
-
-    return Cipherly.encodePasswordPayload({ s: salt, iv: iv, ct: cipherText });
-  }
 </script>
 
 <div class="space-y-8">
   <Section title="Password Encrypt">
     <form
       class="space-y-6"
-      on:submit|preventDefault={() => (payload = encrypt(plainText, password))}
+      on:submit|preventDefault={() =>
+        (payload = passwordEncrypt(plainText, password))}
     >
       <div class="space-y-2">
         <Label


### PR DESCRIPTION
I've added form validation logic to just Auth Encrypt for now, if this looking good, we can add it to other pages using same logic.

![image](https://github.com/shadanan/cipherly/assets/6494584/280dbe8e-6c41-4203-ab4e-b86646fabcc1)

Another example using below schema (demo only):
```typescript
export const AuthEncryptFormSchema = z.object({
  emails: z.array(z.string().email().endsWith("@gmail.com")),
  plainText: z.string().min(1).max(20),
});
```
![image](https://github.com/shadanan/cipherly/assets/6494584/7932f1e9-cb02-4fd7-a810-a6748066c453)

